### PR TITLE
return_errors  could be default true

### DIFF
--- a/src/PSRIO.jl
+++ b/src/PSRIO.jl
@@ -61,7 +61,7 @@ function run(psrio::Pointer, cases::Vector{String};
     horizon::String="",
     logname::String="",
     dependencies_mode::Bool=false,
-    return_errors::Bool=false)
+    return_errors::Bool=true)
     
     recipes_argument = length(recipes) > 0 ? `--recipes $(join(recipes, ','))` : ``
     command_argument = length(command) > 0 ? `--command $command` : ``


### PR DESCRIPTION
In some projects, people forgot to put `return_errors = true` and some tests were broken for a long time. It is a good idea to return errors as a default.