### PR TITLE
chore: bump ArtifactsGenerator to 0.8.1

### DIFF
--- a/scripts/update_artifacts.sh
+++ b/scripts/update_artifacts.sh
@@ -58,7 +58,7 @@ cp "${BASE_PATH}psrio-distribution/linux/PSRIO.ver" \
 # ---------------------------
 
 echo "[INFO] Cloning ArtifactsGenerator..."
-git clone --depth=1 -b 0.8.0 \
+git clone --depth=1 -b 0.8.1 \
   "https://github.com/psrenergy/ArtifactsGenerator.jl.git" \
   "${BASE_PATH}ArtifactsGenerator.jl"
 


### PR DESCRIPTION
Bumps the ArtifactsGenerator.jl pin in scripts/update_artifacts.sh from 0.8.0 to 0.8.1, which forwards the AWS session token through the default credential provider chain and fixes the InvalidAccessKeyId failure when uploading artifacts during the publish workflow. This depends on ArtifactsGenerator.jl PR #14 being merged and tagged 0.8.1 before merging here.